### PR TITLE
Fix the example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,7 @@ second option as a bounce buffer for obvious reasons.
 ## Examples
 
 Some simple examples:
-
-./p2pmem-test /dev/nvme0n1 /dev/nvme1n1 /dev/p2pmem0 -s 1 -4k --check
+./p2pmem-test /dev/nvme0n1 /dev/nvme1n1 /dev/p2pmem0 -c 1 -s 4k --check
 
 Copy one 4KB chunk from /dev/nvme0n1 to /dev/nvme0n1 via the memory
 exposed by /dev/p2pmem0. Perform a check on the data (i.e. write know


### PR DESCRIPTION
Chunk amount and chunk size parameters were not specified correctly in the example.

The patch uses the right command line parameter to specify one data chunk and adds "-s" before the size of the chunk.

Signed-off-by: Yan Vugenfirer <yan@daynix.com>