### PR TITLE
install: Add an install target to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ LDLIBS+= -lpthread
 EXE=p2pmem-test
 SRCS=$(wildcard src/*.c)
 OBJS=$(addprefix $(OBJDIR)/, $(patsubst %.c,%.o, $(SRCS)))
+PREFIX=/usr/local/bin/
 
 ifneq ($(V), 1)
 Q=@
@@ -37,6 +38,9 @@ NQ=:
 endif
 
 compile: $(EXE)
+
+install: $(EXE)
+	install $(EXE) $(PREFIX)
 
 clean:
 	@$(NQ) echo "  CLEAN  $(EXE)"
@@ -63,6 +67,6 @@ $(EXE): $(OBJS) $(LIBARGCONFIGDIR)/libargconfig.a
 	@$(NQ) echo "  LD     $@"
 	$(Q)$(LINK.o) $^ $(LDLIBS) -o $@
 
-.PHONY: clean compile FORCE
+.PHONY: clean compile install FORCE
 
 -include $(patsubst %.o,%.d,$(OBJS))

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ very interesting as NVMe devices become p2pmem devices via the
 Controller Memory Buffer (CMB) and Persistent Memory Region (PMR)
 features.
 
+## Installing
+Should be as simple as:
+```
+git submodule update --init
+make
+sudo make install
+```
+
 ## Contributing
 
 p2pmem-test is an active project. We will happily consider Pull


### PR DESCRIPTION
Add an install target that puts p2pmem-test in an appropriate
place. Update the README with an install section.